### PR TITLE
avoid redundant stringify

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,10 +113,10 @@ pub struct Merino {
 
 impl Merino {
     /// Create a new Merino instance
-    pub fn new(port: u16,  ip: String, auth_methods: Vec<u8>, users: Vec<User>) -> Result<Self, Box<dyn Error>> {
+    pub fn new(port: u16,  ip: &str, auth_methods: Vec<u8>, users: Vec<User>) -> Result<Self, Box<dyn Error>> {
         info!("Listening on {}:{}", ip, port);
         Ok(Merino {
-            listener: TcpListener::bind(format!("{}:{}", ip, port))?,
+            listener: TcpListener::bind((ip, port))?,
             auth_methods,
             users
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 
     // Create proxy server
-    let mut merino = Merino::new(opt.port, opt.ip, auth_methods, authed_users)?;
+    let mut merino = Merino::new(opt.port, &opt.ip, auth_methods, authed_users)?;
 
     // Start Proxies
     merino.serve()?;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,6 +3,6 @@ use merino::*;
 #[test]
 /// Can we crate a new `Merino` instance
 fn merino_contructor() {
-    assert!(Merino::new(1080, "127.0.0.1".to_string(), Vec::new(), Vec::new()).is_ok())
+    assert!(Merino::new(1080, "127.0.0.1", Vec::new(), Vec::new()).is_ok())
 }
 


### PR DESCRIPTION
Tweak `Merino` constructor to avoiding copy within `format!`.