### PR TITLE
use async-await syntax using Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ snafu = "0.4.1"
 csv = "1"
 serde = "1"
 serde_derive = "1"
+tokio = { version = "1", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ struct Opt {
     users: Option<PathBuf>,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", LOGO);
 
     let opt = Opt::from_args();
@@ -91,10 +92,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Create proxy server
-    let mut merino = Merino::new(opt.port, &opt.ip, auth_methods, authed_users)?;
+    let mut merino = Merino::new(opt.port, &opt.ip, auth_methods, authed_users).await?;
 
     // Start Proxies
-    merino.serve()?;
+    merino.serve().await;
 
     Ok(())
 }


### PR DESCRIPTION
Related to #3 and #6

testing using https://github.com/cnlh/benchmark
```bash
benchmark -c 1000 -n 50000 -proxy socks5://127.0.0.1:1080 http://127.0.0.1
```

Original version:
Requests/sec: 44227.51

New (async) version:
Requests/sec: 68251.93 (+54.3%)

