### PR TITLE
Fix authentication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,12 +338,6 @@ impl SOCKClient {
             self.stream.read_exact(&mut plen).await?;
 
             let mut password = vec![0; plen[0] as usize];
-
-            // For some reason the vector needs to actually be full
-            for _ in 0..plen[0] {
-                password.push(0);
-            }
-
             self.stream.read_exact(&mut password).await?;
 
             let username = String::from_utf8_lossy(&username).to_string();


### PR DESCRIPTION
The server tries to read too much data to the password due to the vector being initialized twice.

This patch fixes https://github.com/ajmwagar/merino/issues/14