### PR TITLE
Switch to clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,16 @@ license = "MIT"
 authors = ["Avery Wagar <ajmw.subs@gmail.com>"]
 edition = "2018"
 
+[profile.release]
+opt-level = 3
+lto = true
+
 [dependencies]
 # openssl = { version = "0.10", features = ["vendored"] }
 # rayon = "1.0"
 pretty_env_logger = "0.3.0"
 log = "0.4.6"
-structopt = "0.2"
+clap = { version = "3.0.7", features = ["derive"] }
 snafu = "0.4.1"
 csv = "1"
 serde = "1"


### PR DESCRIPTION
Switching from structopt to latest clap.
This allows getting rid of manual check for `--no-auth` or `--user` and having both of them is now disallowed.
Overall, this helps users to start merino only with a valid authentication configuration.

Also, clap's derive syntax is cleaner.

BTW, binary size is slightly increased from 3.8 MiB to 3.9 MiB