### PR TITLE
Better errors for users file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,12 @@ opt-level = 3
 lto = true
 
 [dependencies]
-# openssl = { version = "0.10", features = ["vendored"] }
-# rayon = "1.0"
-pretty_env_logger = "0.3.0"
-log = "0.4.6"
 clap = { version = "3.0.7", features = ["derive"] }
-snafu = "0.4.1"
-csv = "1"
-serde = "1"
-serde_derive = "1"
-tokio = { version = "1", features = ["full"] }
-thiserror = "1"
+csv = "1.1.6"
+log = "0.4.14"
+pretty_env_logger = "0.4.0"
+serde = "1.0.133"
+serde_derive = "1.0.133"
+snafu = "0.7.0"
+thiserror = "1.0.30"
+tokio = { version = "1.15.0", features = ["full"] }

--- a/baduser.csv
+++ b/baduser.csv
@@ -1,0 +1,4 @@
+username,password
+
+admin,admin
+ajmwagar,password

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,7 @@ fn addr_to_socket(addr_type: &AddrType, addr: &[u8], port: u16) -> io::Result<Ve
         ))]),
         AddrType::Domain => {
             let mut domain = String::from_utf8_lossy(addr).to_string();
-            domain.push_str(":");
+            domain.push(':');
             domain.push_str(&port.to_string());
 
             Ok(domain.to_socket_addrs()?.collect())

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,12 @@
 #[macro_use]
 extern crate log;
 
+use clap::{ArgGroup, Parser};
 use merino::*;
 use std::env;
 use std::error::Error;
+use std::os::unix::prelude::MetadataExt;
 use std::path::PathBuf;
-use clap::{ArgGroup, Parser};
 
 /// Logo to be printed at when merino is run
 const LOGO: &str = r"
@@ -34,6 +35,10 @@ struct Opt {
     #[clap(short, long, default_value = "127.0.0.1")]
     /// Set ip to listen on
     ip: String,
+
+    #[clap(long)]
+    /// Allow insecure configuration
+    allow_insecure: bool,
 
     #[clap(long)]
     /// Allow unauthenticated connections
@@ -72,16 +77,46 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let authed_users: Result<Vec<User>, Box<dyn Error>> = match opt.users {
         Some(users_file) => {
             auth_methods.push(AuthMethods::UserPass as u8);
-            let file = std::fs::File::open(users_file)?;
+            let file = std::fs::File::open(&users_file).unwrap_or_else(|e| {
+                error!("Can't open file {:?}: {}", &users_file, e);
+                std::process::exit(1);
+            });
+
+            let metadata = file.metadata()?;
+            // 7 is (S_IROTH | S_IWOTH | S_IXOTH) or the "permisions for others" in unix
+            if (metadata.mode() & 7) > 0 && !opt.allow_insecure {
+                error!(
+                    "Permissions {:o} for {:?} are too open. \
+                    It is recommended that your users file is NOT accessible by others. \
+                    To override this check, set --allow-insecure",
+                    metadata.mode() & 0o777,
+                    &users_file
+                );
+                std::process::exit(1);
+            }
 
             let mut users: Vec<User> = Vec::new();
 
             let mut rdr = csv::Reader::from_reader(file);
             for result in rdr.deserialize() {
-                let record: User = result?;
+                let record: User = match result {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!("{}", e);
+                        std::process::exit(1);
+                    }
+                };
 
                 trace!("Loaded user: {}", record.username);
                 users.push(record);
+            }
+
+            if users.len() == 0 {
+                error!(
+                    "No users loaded from {:?}. Check configuration.",
+                    &users_file
+                );
+                std::process::exit(1);
             }
 
             Ok(users)

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 users.push(record);
             }
 
-            if users.len() == 0 {
+            if users.is_empty() {
                 error!(
                     "No users loaded from {:?}. Check configuration.",
                     &users_file


### PR DESCRIPTION
Add pretty error messages for the following situations: 
* unable to open a file 
* CSV parse failures.

Also, add a check for permissions on the `users` file. If any permission bits for "everyone" access are set, exit early with an error. `--allow-insecure` flag is added to bypass this check.