### PR TITLE
Make logging tunable by flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - Lightweight (Less than 0.6% CPU usage while surfing the web/streaming YouTube)
 - Standalone binary (no system dependencies)
 - `1+ Gb/second` connection speeds (**On Gigabit LAN network over ethernet. Results may vary!**)
-- Tunable logging (try `export RUST_LOG=merino=DEBUG`)
+- Tunable logging (by flags or `RUST_LOG` environmental variable)
 - `SOCKS5` Compatible Authentication methods:
   - `NoAuth`
   - Username & Password

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,9 @@ const LOGO: &str = r"
     ArgGroup::new("auth")
         .required(true)
         .args(&["no-auth", "users"]),
+), group(
+    ArgGroup::new("log")
+        .args(&["verbosity", "quite"]),
 ))]
 struct Opt {
     #[clap(short, long, default_value_t = 1080)]
@@ -42,6 +45,15 @@ struct Opt {
     #[clap(short, long)]
     /// CSV File with username/password pairs
     users: Option<PathBuf>,
+
+    /// Log verbosity level. -vv for more verbosity.
+    /// Environmental variable `RUST_LOG` overrides this flag!
+    #[clap(short, parse(from_occurrences))]
+    verbosity: u8,
+
+    /// Do not output any logs (even errors!). Overrides `RUST_LOG`
+    #[clap(short)]
+    quite: bool,
 }
 
 #[tokio::main]
@@ -51,13 +63,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let opt = Opt::parse();
 
     // Setup logging
-
-    //Set the `RUST_LOG` var if none is provided
-    if env::var("RUST_LOG").is_err() {
-        env::set_var("RUST_LOG", "merino=INFO");
+    let log_env = env::var("RUST_LOG");
+    if log_env.is_err() {
+        let level = match opt.verbosity {
+            1 => "merino=DEBUG",
+            2 => "merino=TRACE",
+            _ => "merino=INFO",
+        };
+        env::set_var("RUST_LOG", level);
     }
 
-    pretty_env_logger::init_timed();
+    if !opt.quite {
+        pretty_env_logger::init_timed();
+    }
+
+    if log_env.is_ok() && (opt.verbosity != 0) {
+        warn!(
+            "Log level is overriden by environmental variable to `{}`",
+            // It's safe to unwrap() because we checked for is_ok() before
+            log_env.unwrap().as_str()
+        );
+    }
 
     // Setup Proxy settings
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ const LOGO: &str = r"
         .args(&["no-auth", "users"]),
 ), group(
     ArgGroup::new("log")
-        .args(&["verbosity", "quite"]),
+        .args(&["verbosity", "quiet"]),
 ))]
 struct Opt {
     #[clap(short, long, default_value_t = 1080)]
@@ -53,7 +53,7 @@ struct Opt {
 
     /// Do not output any logs (even errors!). Overrides `RUST_LOG`
     #[clap(short)]
-    quite: bool,
+    quiet: bool,
 }
 
 #[tokio::main]
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         env::set_var("RUST_LOG", level);
     }
 
-    if !opt.quite {
+    if !opt.quiet {
         pretty_env_logger::init_timed();
     }
 


### PR DESCRIPTION
Add two flags:
* `-q` for quiet operation. Disables log system completely (only logo is shown).
* `-v` and `-vv` for log levels `debug` and `trace`.

`-q` overrides environmental variable `RUST_LOG`, and `-v` makes no effect if `RUST_LOG` is set.

Setting those flags simultaneously is not allowed (by clap).