### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.63-alpine3.16 as builder
+
+RUN apk add --no-cache git musl-dev
+RUN git clone https://github.com/ajmwagar/merino \
+  && cd merino \
+  && cargo install --path .
+
+FROM alpine:3.16
+
+RUN apk update && apk upgrade
+COPY --from=builder /usr/local/cargo/bin/merino /usr/local/bin/merino
+
+EXPOSE 1080
+ENTRYPOINT ["merino"]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ cd merino
 cargo install --path .
 ```
 
+OR
+
+```bash
+git clone https://github.com/ajmwagar/merino
+cd merino
+docker build -t merino .
+```
+
 ### Usage
 
 ```bash
@@ -53,7 +61,13 @@ merino --no-auth
 merino --users users.csv
 
 # Display a help menu
-merino --help 
+merino --help
+```
+
+#### Docker
+
+```bash
+docker run -it -p 1080:1080 merino --ip 0.0.0.0 --no-auth
 ```
 
 # 🚥 Roadmap


### PR DESCRIPTION
This PR adds a Dockerfile that builds merino and uses the build in an Alpine image.

The README.md is also updated to show instructions on how to build and use the Docker image.