### PR TITLE
Update repository URL for Actix Web framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ merino --help
   - [ ] `BIND`
   - [ ] `ASSOCIATE` 
 - [ ] Benchmarks & Unit tests
-- [ ] [Actix](https://github.com/actix-rs/actix) based backend
+- [ ] [Actix](https://github.com/actix/actix-web) based backend
 - [ ] `SOCKS4`/`SOCKS4a` Support


### PR DESCRIPTION
The old URL for the Actix Web framework does not exist, therefore this PR updates the link to the repository which looks like the successor.